### PR TITLE
Fix object disposed exceptions

### DIFF
--- a/MegaBonkPlusMod/Infrastructure/Http/HttpServer.cs
+++ b/MegaBonkPlusMod/Infrastructure/Http/HttpServer.cs
@@ -129,7 +129,6 @@ public class HttpServer
                 if (resourceStream == null)
                 {
                     context.Response.StatusCode = 404;
-                    context.Response.Close();
                     return;
                 }
 
@@ -141,13 +140,10 @@ public class HttpServer
         {
             ModLogger.LogTrace($"Error serving file '{resourcePath}': {ex}");
             context.Response.StatusCode = 500;
-            context.Response.Close();
         }
         finally
         {
-            if (context.Response.OutputStream.CanWrite) context.Response.OutputStream.Close();
-
-            if (context.Response is not null && context.Response.StatusCode != 404) context.Response.Close();
+            context.Response?.Close();
 
             ModLogger.LogTrace($"Response sent for {context.Request.Url.AbsolutePath}");
         }

--- a/MegaBonkPlusMod/MegaBonkPlusMod.csproj
+++ b/MegaBonkPlusMod/MegaBonkPlusMod.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -9,59 +9,59 @@
 
     <ItemGroup>
         <Reference Include="Assembly-CSharp">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\Assembly-CSharp.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="BepInEx.Core">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\BepInEx.Core.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\BepInEx.Core.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="BepInEx.Unity.Common">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\BepInEx.Unity.Common.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\BepInEx.Unity.Common.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="BepInEx.Unity.IL2CPP">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\BepInEx.Unity.IL2CPP.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\BepInEx.Unity.IL2CPP.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Il2CppInterop.Runtime">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\Il2CppInterop.Runtime.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\core\Il2CppInterop.Runtime.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Il2Cppmscorlib">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\Il2Cppmscorlib.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\Il2Cppmscorlib.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.CoreModule.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.CoreModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.ImageConversionModule">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.ImageConversionModule.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.ImageConversionModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.InputLegacyModule">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.InputLegacyModule.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.InputLegacyModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.InputModule">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\unity-libs\UnityEngine.InputModule.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\unity-libs\UnityEngine.InputModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.JSONSerializeModule">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.JSONSerializeModule.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.JSONSerializeModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.UI">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.UI.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.UI.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.UIModule">
-            <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.UIModule.dll</HintPath>
+            <HintPath>$(AppData)\r2modmanPlus-local\Megabonk\profiles\Default\BepInEx\interop\UnityEngine.UIModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
     </ItemGroup>


### PR DESCRIPTION
The csproj changes are just to improve the setup a bit, so it should work for anyone using r2 modloader now instead of in one specific folder.

And the changes in the HttpServer are to fix the constant ObjectDisposedException spam. This was caused by accessing the OutputStream in the finally block (for the Close call) I double checked the code and the Close on the context.Response already calls the Dispose method for the OutputStream without throwing an exception, so that should fix that behavior.

This also means the flow could be simplified a bit, so the finally block now always handles the Close call.